### PR TITLE
Fix the URL to rustup.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cargo build --features trace_logging
 ```
 
 
-<sup>1</sup> It is recommended to use a tool such as [rustup](rustup.rs) to
+<sup>1</sup> It is recommended to use a tool such as [rustup](https://www.rustup.rs) to
 manage the rust compiler toolchains.
 
 


### PR DESCRIPTION
The current one is pointing to https://github.com/matrix-org/matrix-ircd/blob/master/rustup.rs
