### PR TITLE
Implement part

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -114,7 +114,18 @@ impl<IS: Io> Bridge<IS> {
                     .map(|_| ()).map_err(move |err| warn!(logger, "Failed to join: {}", err))
                 );
             }
-            // TODO: Handle PART
+            IrcCommand::Part { channel } => {
+                if let Some(room_id) = self.mappings.channel_to_room_id(&channel) {
+                    info!(self.ctx.logger, "Leaving channel"; "channel" => room_id.as_str());
+                    let logger = self.ctx.logger.clone();
+                    self.handle.spawn(
+                        self.matrix_client.leave_room(room_id.as_str())
+                        .map(|_| ()).map_err(move |err| warn!(logger, "Failed to part: {}", err))
+                    );
+                } else {
+                    warn!(self.ctx.logger, "Unknown channel"; "channel" => channel.as_str());
+                }
+            }
             c => {
                 warn!(self.ctx.logger, "Ignoring IRC command"; "command" => c.command());
             }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -106,7 +106,14 @@ impl<IS: Io> Bridge<IS> {
                     warn!(self.ctx.logger, "Unknown channel"; "channel" => channel.as_str());
                 }
             }
-            // TODO: Handle JOIN
+            IrcCommand::Join { channel } => {
+                info!(self.ctx.logger, "Joining channel"; "channel" => channel);
+                let logger = self.ctx.logger.clone();
+                self.handle.spawn(
+                    self.matrix_client.join_room(channel.as_str())
+                    .map(|_| ()).map_err(move |err| warn!(logger, "Failed to join: {}", err))
+                );
+            }
             // TODO: Handle PART
             c => {
                 warn!(self.ctx.logger, "Ignoring IRC command"; "command" => c.command());

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -25,6 +25,7 @@ use std::io;
 use tokio_core::reactor::Handle;
 
 use url::Url;
+use url::percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET};
 
 use serde_json;
 use serde::{Serialize, Deserialize};
@@ -114,6 +115,15 @@ impl MatrixClient {
             msgtype: "m.text".into(),
         })
         .map_err(JsonPostError::into_io_error)
+    }
+
+    pub fn join_room(&mut self, room_id: &str) -> impl Future<Item=protocol::RoomJoinResponse, Error=io::Error> {
+        let roomid_encoded = percent_encode(room_id.as_bytes(), PATH_SEGMENT_ENCODE_SET);
+        let mut url = self.url.join(&format!("/_matrix/client/r0/join/{}", roomid_encoded)).unwrap();
+        url.query_pairs_mut()
+            .clear()
+            .append_pair("access_token", &self.access_token);
+        do_json_post("POST", &mut self.http_stream, &url, &protocol::RoomJoinInput { }).map_err(JsonPostError::into_io_error)
     }
 
     pub fn get_room(&self, room_id: &str) -> Option<&Room> {

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -126,6 +126,15 @@ impl MatrixClient {
         do_json_post("POST", &mut self.http_stream, &url, &protocol::RoomJoinInput { }).map_err(JsonPostError::into_io_error)
     }
 
+    pub fn leave_room(&mut self, room_id: &str) -> impl Future<Item=protocol::RoomLeaveResponse, Error=io::Error> {
+        let roomid_encoded = percent_encode(room_id.as_bytes(), PATH_SEGMENT_ENCODE_SET);
+        let mut url = self.url.join(&format!("/_matrix/client/r0/rooms/{}/leave", roomid_encoded)).unwrap();
+        url.query_pairs_mut()
+            .clear()
+            .append_pair("access_token", &self.access_token);
+        do_json_post("POST", &mut self.http_stream, &url, &protocol::RoomLeaveInput { }).map_err(JsonPostError::into_io_error)
+    }
+
     pub fn get_room(&self, room_id: &str) -> Option<&Room> {
         self.rooms.get(room_id)
     }

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -128,7 +128,8 @@ impl MatrixClient {
 
     pub fn leave_room(&mut self, room_id: &str) -> impl Future<Item=protocol::RoomLeaveResponse, Error=io::Error> {
         let roomid_encoded = percent_encode(room_id.as_bytes(), PATH_SEGMENT_ENCODE_SET);
-        let mut url = self.url.join(&format!("/_matrix/client/r0/rooms/{}/leave", roomid_encoded)).unwrap();
+        let mut url = self.url.join(&format!("/_matrix/client/r0/rooms/{}/leave", roomid_encoded))
+            .expect("Unable to construct a valid API url");
         url.query_pairs_mut()
             .clear()
             .append_pair("access_token", &self.access_token);

--- a/src/matrix/protocol.rs
+++ b/src/matrix/protocol.rs
@@ -79,6 +79,16 @@ pub struct LoginResponse {
     pub user_id: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct RoomJoinInput {
+    // third_party_signed at some point
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RoomJoinResponse {
+    pub room_id: String,
+}
+
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RoomSendInput {

--- a/src/matrix/protocol.rs
+++ b/src/matrix/protocol.rs
@@ -89,6 +89,13 @@ pub struct RoomJoinResponse {
     pub room_id: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct RoomLeaveInput {
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RoomLeaveResponse {
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RoomSendInput {


### PR DESCRIPTION
This relies on #19 being merged. It works perfectly fine as far as the matrix side of things is concerned, though when I tried it on weechat it didn't automatically close the chat buffer; not sure if that's weechat's fault or does some feedback irc message needs to be sent back to the user? Also, `RoomLeaveInput` and `RoomLeaveResponse` exist only to satisfy the `do_json_post`'s API; perhaps it'd be better to either teach `do_json_post` to deal with empty payloads, or create a dummy struct for those? What do you think?
