### PR TITLE
Handle multiline matrix messages

### DIFF
--- a/src/irc/mod.rs
+++ b/src/irc/mod.rs
@@ -154,7 +154,10 @@ impl<S: Io> IrcUserConnection<S> {
     }
 
     pub fn send_message(&mut self, channel: &str, sender: &str, body: &str) {
-        self.conn.write_line(&format!(":{} PRIVMSG {} :{}", sender, channel, body));
+        let s = String::from(body);
+        for line in s.split("\n") {
+            self.conn.write_line(&format!(":{} PRIVMSG {} :{}", sender, channel, line));
+        }
     }
 
     pub fn write_invalid_password(&mut self) {

--- a/src/irc/mod.rs
+++ b/src/irc/mod.rs
@@ -154,8 +154,7 @@ impl<S: Io> IrcUserConnection<S> {
     }
 
     pub fn send_message(&mut self, channel: &str, sender: &str, body: &str) {
-        let s = String::from(body);
-        for line in s.split("\n") {
+        for line in body.split("\n") {
             self.conn.write_line(&format!(":{} PRIVMSG {} :{}", sender, channel, line));
         }
     }


### PR DESCRIPTION
...by splitting them into multiple lines. Best we can do, given IRC limitations.

Fixes #13 and #24 