### PR TITLE
Add dockerfile with binary

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+target
+Dockerfile
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust:1.40 as builder
+WORKDIR /usr/src/myapp
+COPY . .
+RUN cargo install --path .
+
+FROM debian:buster-slim
+RUN apt-get update && apt-get -y install ca-certificates libssl-dev && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/cargo/bin/matrix-ircd /usr/local/bin/matrix-ircd
+ENTRYPOINT ["matrix-ircd"]


### PR DESCRIPTION
Seems to work so far

Attaching as a comment a nice makefile, but didn't think it was a requirement for the PR.

Makefile:
```
.DEFAULT_GOAL := build

NAME = matrix-ircd
TAGNAME = halkeye/$(NAME)
VERSION = latest

build: ## Build docker image
        docker build -t $(TAGNAME):$(VERSION) .

push: ## push to docker hub
        docker push $(TAGNAME):$(VERSION)

run:
        docker run -it --name $(NAME) -p 5999:5999 $(TAGNAME):$(VERSION)

.PHONY: help
help:
        @grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
```