### PR TITLE
Add snapcraft packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+*.snap

--- a/README.md
+++ b/README.md
@@ -63,6 +63,49 @@ on TLS, otherwise it will use plain TCP.
 The credentials for the matrix account are taken from the user name and server
 password specified by the IRC connection.
 
+## Snap
+
+This software includes packaging information for [Snapcraft](https://snapcraft.io).
+Building the snap package is as simple as installing as running `snapcraft` in the
+top-level directory of this repository. The resulting snap, until the snap is published
+on `snapcraft.io`, can be installed locally by using the `--dangerous` option to
+`snap install`. `--dangerous` is only needed as local snaps are not cryptographically
+signed.
+
+The `matrix-ircd` daemon is configured in the snap package to read an environment file,
+which allows customisation of the parameters documented in the usage section. The
+environment file is a bash script which sets several environment variable, which are
+loaded by the systemd service file which runs `matrix-ircd` inside the snap environment.
+
+To configure the service, create a file in `/var/snap/matrix-ircd/common` named
+`matrix-ircd.env`, and set the following variables inside:
+
+`MATRIX_IRCD_HOMESERVER`
+Maps to the `--url` parameter, points to the home server you wold like `matrix-ircd` to
+connect to.
+Example: `MATRIX_IRCD_HOMESERVER=https://example.homeserver:8989`
+
+`MATRIX_IRCD_BIND`
+Maps to the `--bind` parameter, sets the IP and port you would like `matrix-ircd` to listen
+on for IRC connections.
+Example: `MATRIX_IRCD_BIND=0.0.0.0:9001`
+
+If you would like to use TLS, both of the following settings will need to be set.
+If you would not like to use TLS, do not include these settings in your environment file.
+
+`MATRIX_IRCD_PASSWORD`
+Sets the password used to access the PKCS#12 certificate bundle.
+Example: `MATRIX_IRCD_PASSWORD=Passw0rd`
+
+`MATRIX_IRCD_PKCS12`
+Sets the filename of the PKCS#12 certificate bundle. This file must be located in the
+`/var/snap/matrix-ircd/common` directory.
+Example: `matrix-ircd.pfx`
+
+With all of these parameters set, you should be able to start the service with:
+`systemctl start snap.matrix-ircd.matrix-ircd`
+Any errors with your configuration will be record in the system's `journald` logs
+for the service.
 
 ## Development
 

--- a/snap/local/matrix-ircd-wrapper
+++ b/snap/local/matrix-ircd-wrapper
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [ -f "${SNAP_COMMON}/matrix-ircd.env" ]; then
+    source "${SNAP_COMMON}/matrix-ircd.env"
+else
+    echo "No matrix-ircd.env file found in ${SNAP_COMMON}"
+    exit 1
+fi
+
+ARGS=""
+
+if [ ! -z "$MATRIX_IRCD_HOMESERVER" ]; then
+    ARGS="${ARGS} --url ${MATRIX_IRCD_HOMESERVER}"
+fi
+
+if [ ! -z "$MATRIX_IRCD_BIND" ]; then
+    ARGS="${ARGS} --bind ${MATRIX_IRCD_BIND}"
+fi
+
+if [ ! -z "$MATRIX_IRCD_PASSWORD" ] && [ ! -z "$MATRIX_IRCD_PKCS12" ]; then
+    ARGS="${ARGS} --password ${MATRIX_IRCD_PASSWORD} --pkcs12 ${SNAP_COMMON}/${MATRIX_IRCD_PKCS12}"
+fi
+
+echo "Running matrix-ircd with ${ARGS}"
+matrix-ircd ${ARGS}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,33 @@
+---
+name: matrix-ircd
+base: core18
+version: git
+summary: An IRC client bridge into Matrix
+description: |
+    This is project is almost the inverse of matrix-appservice-irc.
+    matrix-ircd lets you use any standard IRC Client to communicate with Matrix,
+    as a Matrix client.
+
+grade: stable
+confinement: strict
+
+apps:
+  matrix-ircd:
+    command: matrix-ircd-wrapper
+    plugs: [network-bind, network]
+    daemon: simple
+parts:
+  matrix-ircd:
+    source: .
+    plugin: rust
+    build-packages:
+      - pkg-config
+      - libssl-dev
+  matrix-ircd-wrapper:
+    source: snap/local
+    source-type: local
+    plugin: dump
+    after:
+      - matrix-ircd
+    organize:
+      matrix-ircd-wrapper: bin/matrix-ircd-wrapper


### PR DESCRIPTION
Hello,

This PR adds snapcraft packaging information for matrix-ircd - which in addition to allowing folks to easily deploy the daemon, also adds a level of confinement to the process. I have added a small wrapper to allow the daemon to use a `.env` file to read parameters, so that the daemon can easily be run as a systemd unit. I have been working on creating snapcraft packaging for various parts of the Matrix ecosystem and matrix-ircd is something I'm keen to get deploying via snap, along with synapse which has also had snapcraft packaging metadata merged.

I have tested this locally and haven't found any issues.

If/when this is merged, it would be possible to register this repo with the snapcraft store (snapcraft.io) so that builds could automatically be pushed as commits are pushed to this repo - the metadata from the git repository is currently used by this snapcraft packaging to derive version information, so if annotated tags were added along with releases, the snap will pick them up and use that version when setting the version of the package.

Please let me know if you have any questions or concerns! 

Signed-off-by: James Hebden <james@ec0.io>