### PR TITLE
GSOC 2020: Move from tokio::task::spawn_local to tokio::spawn

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -41,7 +41,7 @@ use url::Url;
 ///
 /// The `Bridge` object is a future that resolves when the IRC connection closes the session (or
 /// on unrecoverable error).
-pub struct Bridge<IS: AsyncRead + AsyncWrite + 'static> {
+pub struct Bridge<IS: AsyncRead + AsyncWrite + Send + 'static> {
     irc_conn: Pin<Box<IrcUserConnection<IS>>>,
     matrix_client: Pin<Box<MatrixClient>>,
     ctx: ConnectionContext,
@@ -316,7 +316,7 @@ struct MappingStore {
 }
 
 impl MappingStore {
-    pub fn insert_nick<S: AsyncRead + AsyncWrite + 'static>(
+    pub fn insert_nick<S: AsyncRead + AsyncWrite + Send + 'static>(
         &mut self,
         irc_server: &mut IrcUserConnection<S>,
         nick: String,
@@ -337,7 +337,7 @@ impl MappingStore {
         self.room_id_to_channel.get(room_id)
     }
 
-    pub async fn create_or_get_channel_name_from_matrix<S: AsyncRead + AsyncWrite + 'static>(
+    pub async fn create_or_get_channel_name_from_matrix<S: AsyncRead + AsyncWrite + Send + 'static>(
         &mut self,
         irc_server: &mut IrcUserConnection<S>,
         room: &MatrixRoom,
@@ -417,7 +417,7 @@ impl MappingStore {
         (channel, true)
     }
 
-    pub fn create_or_get_nick_from_matrix<S: AsyncRead + AsyncWrite + 'static>(
+    pub fn create_or_get_nick_from_matrix<S: AsyncRead + AsyncWrite + Send + 'static>(
         &mut self,
         irc_server: &mut IrcUserConnection<S>,
         user_id: &str,

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -337,7 +337,9 @@ impl MappingStore {
         self.room_id_to_channel.get(room_id)
     }
 
-    pub async fn create_or_get_channel_name_from_matrix<S: AsyncRead + AsyncWrite + Send + 'static>(
+    pub async fn create_or_get_channel_name_from_matrix<
+        S: AsyncRead + AsyncWrite + Send + 'static,
+    >(
         &mut self,
         irc_server: &mut IrcUserConnection<S>,
         room: &MatrixRoom,

--- a/src/http.rs
+++ b/src/http.rs
@@ -19,3 +19,13 @@ impl ClientWrapper {
         self.inner.request(request)
     }
 }
+
+#[cfg(test)]
+mod send_tests {
+    fn is_send<T: Send>(_: T) {}
+    #[test]
+    fn http_client() {
+        let http = crate::http::ClientWrapper::new();
+        is_send(http);
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -13,19 +13,9 @@ impl ClientWrapper {
         }
     }
     pub(crate) fn send_request(
-        &mut self,
+        &self,
         request: Request<hyper::Body>,
     ) -> hyper::client::ResponseFuture {
         self.inner.request(request)
-    }
-}
-
-#[cfg(test)]
-mod send_tests {
-    fn is_send<T: Send>(_: T) {}
-    #[test]
-    fn http_client() {
-        let http = crate::http::ClientWrapper::new();
-        is_send(http);
     }
 }

--- a/src/irc/mod.rs
+++ b/src/irc/mod.rs
@@ -362,7 +362,7 @@ where
 
 #[cfg(test)]
 mod send_tests {
-    fn is_send<T:Send>(_: T) {}
+    fn is_send<T: Send>(_: T) {}
     #[test]
     fn user_nick_builder() {
         let ctx = crate::ConnectionContext::testing_context();

--- a/src/irc/mod.rs
+++ b/src/irc/mod.rs
@@ -35,9 +35,6 @@ use std::pin::Pin;
 
 use slog::{info, trace};
 
-// TODO: remove this before pr
-pub use transport::IrcServerConnection;
-
 pub struct IrcUserConnection<S: AsyncRead + AsyncWrite + Send> {
     conn: Pin<Box<transport::IrcServerConnection<S>>>,
     pub user: String,
@@ -357,30 +354,5 @@ where
                 None => return Poll::Ready(Ok(None)),
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod send_tests {
-    fn is_send<T: Send>(_: T) {}
-    #[test]
-    fn user_nick_builder() {
-        let ctx = crate::ConnectionContext::testing_context();
-        let builder = super::UserNickBuilder::with_context(ctx);
-        is_send(builder);
-    }
-    #[test]
-    fn ref_cell_user_nick() {
-        let ctx = crate::ConnectionContext::testing_context();
-        let builder = super::UserNickBuilder::with_context(ctx);
-        let refcell = std::cell::RefCell::new(builder);
-        is_send(refcell)
-    }
-    #[test]
-    fn user_nick_builder() {
-        //let ctx = crate::ConnectionContext::testing_context();
-        //let builder = super::UserNickBuilder::with_context(ctx);
-        //let fold = crate::StreamFold::new(
-        //is_send(builder);
     }
 }

--- a/src/irc/models.rs
+++ b/src/irc/models.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Mutex;
 
 #[derive(Debug, Clone)]
 pub struct Channel {

--- a/src/irc/models.rs
+++ b/src/irc/models.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Mutex;
 
 #[derive(Debug, Clone)]
 pub struct Channel {

--- a/src/irc/transport.rs
+++ b/src/irc/transport.rs
@@ -256,12 +256,8 @@ where
 
             let bytes_written = {
                 let to_write = &inner.write_buffer.get_ref()[pos..];
-                let bytes = self.conn.as_mut().write(to_write).await?;
-                std::mem::drop(inner);
-                bytes
+                self.conn.as_mut().write(to_write).await?
             };
-
-            let mut inner = self.inner.lock().unwrap();
 
             inner
                 .write_buffer

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,7 +226,7 @@ async fn main() {
             //
             // These are spawn_local due to it not requiring spawn_fut to be Send, but it could
             // possibly be `spawn` in the future after changing trait bounds.
-            tokio::task::spawn_local(spawn_fut);
+            tokio::spawn(spawn_fut);
         } else {
             // Same as above except with less TLS.
             let spawn_fut = future::lazy(move |_cx: &mut Context| async move {
@@ -250,5 +250,15 @@ async fn main() {
 
             tokio::task::spawn_local(spawn_fut);
         };
+    }
+}
+
+#[cfg(test)]
+mod send_tests {
+    fn is_send<T:Send>(_: T) {}
+    #[test]
+    fn connection_context() {
+        let ctx = super::ConnectionContext::testing_context();
+        is_send(ctx);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,17 +251,7 @@ async fn main() {
                 }
             });
 
-            tokio::task::spawn_local(spawn_fut);
+            tokio::spawn(spawn_fut);
         };
-    }
-}
-
-#[cfg(test)]
-mod send_tests {
-    fn is_send<T: Send>(_: T) {}
-    #[test]
-    fn connection_context() {
-        let ctx = super::ConnectionContext::testing_context();
-        is_send(ctx);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,7 +167,10 @@ async fn main() {
         let addr = if let Ok(addr) = tcp_stream.peer_addr() {
             addr
         } else {
-            debug!(log, "Could not fetch peer address from tcp stream. Bridge will not be setup");
+            debug!(
+                log,
+                "Could not fetch peer address from tcp stream. Bridge will not be setup"
+            );
             continue;
         };
 
@@ -255,7 +258,7 @@ async fn main() {
 
 #[cfg(test)]
 mod send_tests {
-    fn is_send<T:Send>(_: T) {}
+    fn is_send<T: Send>(_: T) {}
     #[test]
     fn connection_context() {
         let ctx = super::ConnectionContext::testing_context();

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -94,7 +94,7 @@ impl MatrixClient {
         password: String,
         ctx: ConnectionContext,
     ) -> Result<MatrixClient, Error> {
-        let mut http_client = http::ClientWrapper::new();
+        let http_client = http::ClientWrapper::new();
 
         let login = protocol::LoginPasswordInput {
             user,
@@ -387,24 +387,5 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(200));
 
         mock_req.assert();
-    }
-}
-
-#[cfg(test)]
-mod send_tests {
-    fn is_send<T: Send>(_: T) {}
-    //#[test]
-    //fn matrix_client() {
-    //    let ctx = crate::ConnectionContext::testing_context();
-    //    let http = crate::http::ClientWrapper::new();
-    //    let client = super::MatrixClient::new(http, "asd".parse().unwrap(), "asd".into(), "asd".into(), ctx);
-    //    is_send(client);
-    //}
-    #[test]
-    fn matrix_sync() {
-        let ctx = crate::ConnectionContext::testing_context();
-        let client =
-            super::sync::MatrixSyncClient::new(&url::Url::parse("asd").unwrap(), "asd".into(), ctx);
-        is_send(client);
     }
 }

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -389,3 +389,22 @@ mod tests {
         mock_req.assert();
     }
 }
+
+#[cfg(test)]
+mod send_tests {
+    fn is_send<T:Send>(_: T) {}
+    //#[test]
+    //fn matrix_client() {
+    //    let ctx = crate::ConnectionContext::testing_context();
+    //    let http = crate::http::ClientWrapper::new();
+    //    let client = super::MatrixClient::new(http, "asd".parse().unwrap(), "asd".into(), "asd".into(), ctx);
+    //    is_send(client);
+    //}
+    #[test]
+    fn matrix_sync() {
+
+        let ctx = crate::ConnectionContext::testing_context();
+        let client = super::sync::MatrixSyncClient::new(&url::Url::parse("asd").unwrap(), "asd".into(), ctx);
+        is_send(client);
+    }
+}

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -392,7 +392,7 @@ mod tests {
 
 #[cfg(test)]
 mod send_tests {
-    fn is_send<T:Send>(_: T) {}
+    fn is_send<T: Send>(_: T) {}
     //#[test]
     //fn matrix_client() {
     //    let ctx = crate::ConnectionContext::testing_context();
@@ -402,9 +402,9 @@ mod send_tests {
     //}
     #[test]
     fn matrix_sync() {
-
         let ctx = crate::ConnectionContext::testing_context();
-        let client = super::sync::MatrixSyncClient::new(&url::Url::parse("asd").unwrap(), "asd".into(), ctx);
+        let client =
+            super::sync::MatrixSyncClient::new(&url::Url::parse("asd").unwrap(), "asd".into(), ctx);
         is_send(client);
     }
 }

--- a/src/matrix/sync.rs
+++ b/src/matrix/sync.rs
@@ -16,7 +16,6 @@ use serde_json;
 
 use std::boxed::Box;
 use std::io;
-use std::ops::DerefMut;
 use std::pin::Pin;
 use std::sync::Mutex;
 use std::task::Context;
@@ -64,7 +63,7 @@ impl MatrixSyncClient {
         loop {
             let mut current_sync = self.current_sync.lock().unwrap();
 
-            match &mut current_sync.deref_mut() {
+            match &mut *current_sync {
                 // There is currently no active request to the matrix server, so we make one
                 RequestStatus::NoRequest => {
                     let new_request_status = self.make_request();

--- a/src/matrix/sync.rs
+++ b/src/matrix/sync.rs
@@ -140,7 +140,7 @@ impl MatrixSyncClient {
 
         let request = hyper::Request::builder()
             .method("GET")
-            .uri(self.url.as_str().parse::<hyper::Uri>().unwrap())
+            .uri(url.as_str().parse::<hyper::Uri>().unwrap())
             .body(hyper::Body::empty())
             .expect("request could not be built");
 


### PR DESCRIPTION
This PR makes all types `Send`, as well as some types (such as `StreamFold`) `Sync` as per some of the feedback in #71. Additionally, a few methods were modified to take `&self` instead of `&mut self` to satisfy compiler errors with aliasing as a result of some additional `Mutex`s.

One important note here is that all mutexes added are from `std`. In the future, this should be updated to use `tokio::sync::Mutex`, but current method signatures (non-async) currently prevent this. 