### PR TITLE
Implement IRC away / unaway

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -157,6 +157,13 @@ impl<IS: AsyncRead + AsyncWrite + 'static> Bridge<IS> {
                 // TODO: Handle failure of join. Ensure that joining map is cleared.
                 self.spawn(join_future);
             }
+            IrcCommand::Away { message } => {
+                if message.is_empty() {
+                    self.irc_conn.unaway();
+                } else {
+                    self.irc_conn.away();
+                }
+            }
             // TODO: Handle PART
             c => {
                 warn!(self.ctx.logger, "Ignoring IRC command"; "command" => c.command());

--- a/src/irc/mod.rs
+++ b/src/irc/mod.rs
@@ -226,6 +226,22 @@ impl<S: AsyncRead + AsyncWrite + 'static> IrcUserConnection<S> {
         self.conn.write_line(line);
     }
 
+    pub fn away(&mut self) {
+        self.conn.write_numeric(
+            Numeric::RplNowaway,
+            &self.nick,
+            "You are now away",
+        );
+    }
+
+    pub fn unaway(&mut self) {
+        self.conn.write_numeric(
+            Numeric::RplUnaway,
+            &self.nick,
+            "Welcome back",
+        );
+    }
+
     fn handle_who_channel_cmd(&mut self, channel: String) {
         let IrcUserConnection {
             ref mut server_model,


### PR DESCRIPTION
Just enough so that if your IRC client keeps an away log (like e.g.
irssi does), then it can properly start/stop as you go into away mode or
get out of it.

Fixes #73

I imagine the patch is simple enough, but if it helps, I'm happy to wait till the port to async/await is done, and then I can rebase this on top of a newer master.