### PR TITLE
GSOC 2020: Bugfixes and improvements to broken async await patch 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,9 +1238,9 @@ checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
 
 [[package]]
 name = "tokio"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
+checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-tls",
+]
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +565,7 @@ dependencies = [
  "clap",
  "futures",
  "hyper",
+ "hyper-tls",
  "lazy_static",
  "mockito",
  "native-tls",
@@ -1262,6 +1276,16 @@ name = "tokio-native-tls"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd608593a919a8e05a7d1fc6df885e40f6a88d3a70a3a7eff23ff27964eda069"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rand = "0.7.3"
 regex = "1.3.9"
 serde = {version="1.0.111", features=["derive"]}
 serde_json = "1.0.53"
-slog = {version = "2.5.2", features = ["max_level_debug"]}
+slog = { version = "2.5.2", features = ["max_level_debug"] }
 slog-async = "2.5.0"
 slog-term = "2.4.0"
 url = "1.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "0.2.21", features=["full"] }
 hyper = "0.13.6"
 native-tls = "0.2.4"
 tokio-native-tls = "0.1.0"
+hyper-tls = "0.4.3"
 
 [dependencies.openssl]
 version = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rand = "0.7.3"
 regex = "1.3.9"
 serde = {version="1.0.111", features=["derive"]}
 serde_json = "1.0.53"
-slog = {version = "2.5.2", features = ["max_level_trace"]}
+slog = {version = "2.5.2", features = ["max_level_debug"]}
 slog-async = "2.5.0"
 slog-term = "2.4.0"
 url = "1.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ rand = "0.7.3"
 regex = "1.3.9"
 serde = {version="1.0.111", features=["derive"]}
 serde_json = "1.0.53"
-slog = "2.5.2"
+slog = {version = "2.5.2", features = ["max_level_trace"]}
 slog-async = "2.5.0"
 slog-term = "2.4.0"
 url = "1.7.2"
-tokio = { version = "0.2.21", features=["full"] }
+tokio = { version = "0.2.22", features=["full"] }
 hyper = "0.13.6"
 native-tls = "0.2.4"
 tokio-native-tls = "0.1.0"

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -62,8 +62,13 @@ impl<IS: AsyncRead + AsyncWrite + 'static + Send> Bridge<IS> {
         irc_server_name: String,
         ctx: ConnectionContext,
     ) -> Result<Bridge<IS>, Error> {
+        debug!(ctx.logger.as_ref(),"Starting irc connection");
+
         // make individual connections
         let irc_conn = IrcUserConnection::await_login(irc_server_name, stream, ctx.clone()).await?;
+
+        debug!(ctx.logger.as_ref(), "successfully created the bridge irc connection");
+
         let matrix_client = MatrixClient::login(
             base_url,
             irc_conn.user.clone(),
@@ -71,6 +76,8 @@ impl<IS: AsyncRead + AsyncWrite + 'static + Send> Bridge<IS> {
             ctx.clone(),
         )
         .await?;
+
+        debug!(ctx.logger.as_ref(), "successfully constructed a new matrix client");
 
         // setup connections to intermediate bridge
         let mut bridge = Bridge {

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -62,18 +62,26 @@ impl<IS: AsyncRead + AsyncWrite + 'static + Send> Bridge<IS> {
         irc_server_name: String,
         ctx: ConnectionContext,
     ) -> Result<Bridge<IS>, Error> {
-        debug!(ctx.logger.as_ref(),"Starting irc connection");
+        debug!(ctx.logger.as_ref(), "Starting irc connection");
 
         // make individual connections
-        let irc_conn = match IrcUserConnection::await_login(irc_server_name, stream, ctx.clone()).await {
-            Ok(conn) => conn,
-            Err(err) => {
-                warn!(ctx.logger.as_ref(), "IrcUserConnection could not be created. Error: {}", err.to_string());
-                return Err(Error::from(err))
-            }
-        };
+        let irc_conn =
+            match IrcUserConnection::await_login(irc_server_name, stream, ctx.clone()).await {
+                Ok(conn) => conn,
+                Err(err) => {
+                    warn!(
+                        ctx.logger.as_ref(),
+                        "IrcUserConnection could not be created. Error: {}",
+                        err.to_string()
+                    );
+                    return Err(Error::from(err));
+                }
+            };
 
-        debug!(ctx.logger.as_ref(), "successfully created the bridge irc connection");
+        debug!(
+            ctx.logger.as_ref(),
+            "successfully created the bridge irc connection"
+        );
 
         let matrix_client = MatrixClient::login(
             base_url,
@@ -83,7 +91,10 @@ impl<IS: AsyncRead + AsyncWrite + 'static + Send> Bridge<IS> {
         )
         .await?;
 
-        debug!(ctx.logger.as_ref(), "successfully constructed a new matrix client");
+        debug!(
+            ctx.logger.as_ref(),
+            "successfully constructed a new matrix client"
+        );
 
         // setup connections to intermediate bridge
         let mut bridge = Bridge {

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -65,7 +65,13 @@ impl<IS: AsyncRead + AsyncWrite + 'static + Send> Bridge<IS> {
         debug!(ctx.logger.as_ref(),"Starting irc connection");
 
         // make individual connections
-        let irc_conn = IrcUserConnection::await_login(irc_server_name, stream, ctx.clone()).await?;
+        let irc_conn = match IrcUserConnection::await_login(irc_server_name, stream, ctx.clone()).await {
+            Ok(conn) => conn,
+            Err(err) => {
+                warn!(ctx.logger.as_ref(), "IrcUserConnection could not be created. Error: {}", err.to_string());
+                return Err(Error::from(err))
+            }
+        };
 
         debug!(ctx.logger.as_ref(), "successfully created the bridge irc connection");
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,15 +1,17 @@
 use hyper::{self, client::HttpConnector, Request};
+use hyper_tls::HttpsConnector;
 
 // TODO: can probably drop this whole struct later, just keeping things somewhat similar to how
 // futures 0.1 worked to keep apis potentially similar as the port happens
 pub struct ClientWrapper {
-    inner: hyper::Client<HttpConnector>,
+    inner: hyper::Client<HttpsConnector<HttpConnector>>,
 }
 
 impl ClientWrapper {
     pub(crate) fn new() -> Self {
+        let https = HttpsConnector::new();
         Self {
-            inner: hyper::Client::new(),
+            inner: hyper::Client::builder().build(https),
         }
     }
     pub(crate) fn send_request(

--- a/src/irc/mod.rs
+++ b/src/irc/mod.rs
@@ -63,7 +63,7 @@ impl std::fmt::Debug for UserNickBuilder {
             .field("real_name", &self.real_name)
             .field("password", &self.password)
             .finish()
-     }
+    }
 }
 
 impl UserNickBuilder {
@@ -81,7 +81,10 @@ impl UserNickBuilder {
 impl UserNickBuilder {
     fn to_user_nick(self) -> Result<UserNick, io::Error> {
         if self.is_complete() {
-            debug!(self.ctx.logger.as_ref(), "UserNickBuilder is marked as complete, converting to UserNick");
+            debug!(
+                self.ctx.logger.as_ref(),
+                "UserNickBuilder is marked as complete, converting to UserNick"
+            );
 
             Ok(UserNick {
                 nick: self.nick.unwrap(),
@@ -89,17 +92,16 @@ impl UserNickBuilder {
                 real_name: self.real_name.unwrap(),
                 password: self.password,
             })
-        }
-        else {
-            warn!(self.ctx.logger.as_ref(), "UserNickBuilder that was returned from StreamFold was not complete");
+        } else {
+            warn!(
+                self.ctx.logger.as_ref(),
+                "UserNickBuilder that was returned from StreamFold was not complete"
+            );
 
-            Err(
-                io::Error::new(
-                    io::ErrorKind::UnexpectedEof,
-                    "Unable to build a UserNick from the TCP stream"
-                )
-            )
-
+            Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "Unable to build a UserNick from the TCP stream",
+            ))
         }
     }
 
@@ -117,7 +119,7 @@ impl crate::stream_fold::StateUpdate<Result<IrcCommand, io::Error>> for UserNick
             Ok(cmd) => cmd,
             Err(error) => {
                 debug!(self.ctx.logger, "Failed parse command: {}", error);
-                return false
+                return false;
             }
         };
 
@@ -134,10 +136,8 @@ impl crate::stream_fold::StateUpdate<Result<IrcCommand, io::Error>> for UserNick
                 debug!(self.ctx.logger, "Ignore command during login"; "cmd" => c.command());
             }
         }
-        
+
         let complete = self.is_complete();
-        println!("::::::::::::::::::::");
-        dbg!{complete};
 
         complete
     }
@@ -179,7 +179,10 @@ where
         // user_nick below
         (&folder).await;
 
-        debug!(ctx_clone.logger, "StreamFold finished, now splitting into individual parts");
+        debug!(
+            ctx_clone.logger,
+            "StreamFold finished, now splitting into individual parts"
+        );
 
         let (mut irc_conn, user_nick) = folder.into_parts();
 

--- a/src/irc/transport.rs
+++ b/src/irc/transport.rs
@@ -163,7 +163,7 @@ where
             }
 
             let start_len = self.read_buffer.len();
-            if start_len >= 2048 {
+            if start_len >= 2048*10 {
                 return Poll::Ready(Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "Line too long",
@@ -284,6 +284,7 @@ impl<S: AsyncRead + AsyncWrite + Send> Stream for IrcServerConnection<S> {
         trace!(self.ctx.logger, "IRC Polled");
 
         if self.closed {
+            debug!(self.ctx.logger, "IRC is closed, returning None from IrcServerConnection");
             return Poll::Ready(None);
         }
 
@@ -298,6 +299,7 @@ impl<S: AsyncRead + AsyncWrite + Send> Stream for IrcServerConnection<S> {
         }
 
         if self.closed {
+            debug!(self.ctx.logger, "IRC was closed in IrcServerConnection::poll_read returning None from stream");
             Poll::Ready(None)
         } else {
             Poll::Pending

--- a/src/irc/transport.rs
+++ b/src/irc/transport.rs
@@ -69,7 +69,7 @@ where
             }
 
             if let Some(ref waker) = inner.waker {
-                waker.wake_by_ref()
+                waker.wake_by_ref();
             }
         }
 
@@ -223,7 +223,7 @@ where
             let mut inner = self.inner.lock().unwrap();
 
             if inner.waker.is_none() {
-                inner.waker = Some(cx.waker().clone())
+                inner.waker = Some(cx.waker().clone());
             }
 
             if inner.write_buffer.get_ref().is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,26 +240,20 @@ async fn main() {
 
                 let mut bridge =
                     bridge::Bridge::create(cloned_url, tcp_stream, irc_server_name, ctx.clone())
-                        .await;
+                        .await
+                        .unwrap();
 
-                match bridge {
-                    Ok(mut bridge) => {
-                        debug!(ctx.logger.as_ref(), "Successfully made bridge");
+                loop {
+                    debug!(ctx.logger.as_ref(), "Polling bridge and matrix for changes");
 
-                        loop {
-                            debug!(ctx.logger.as_ref(), "Polling bridge and matrix for changes");
-
-                            if let Err(e) = bridge.poll_irc().await {
-                                task_warn!(ctx, "Encounted error while polling IRC connection"; "error" => format!{"{}", e});
-                                break;
-                            }
-                            if let Err(e) = bridge.poll_matrix().await {
-                                task_warn!(ctx, "Encounted error while polling matrix connection"; "error" => format!{"{}", e});
-                                break;
-                            }
-                        }
+                    if let Err(e) = bridge.poll_irc().await {
+                        task_warn!(ctx, "Encounted error while polling IRC connection"; "error" => format!{"{}", e});
+                        break;
                     }
-                    Err(e) => (),
+                    if let Err(e) = bridge.poll_matrix().await {
+                        task_warn!(ctx, "Encounted error while polling matrix connection"; "error" => format!{"{}", e});
+                        break;
+                    }
                 }
             };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,11 +24,9 @@ use std::fs::File;
 use std::io::{self, Read};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::task::Context;
 
 use clap::{App, Arg};
 
-use futures::future;
 use futures::stream::StreamExt;
 
 use slog::Drain;
@@ -162,9 +160,14 @@ async fn main() {
 
     info!(log, "Started listening"; "addr" => bind_addr, "tls" => tls);
 
+
     // This is the main loop where we accept incoming *TCP* connections.
     while let Some(Ok(tcp_stream)) = socket.next().await {
         let addr = if let Ok(addr) = tcp_stream.peer_addr() {
+            debug!(
+                log,
+                "{}", format!("Got TCP stream with address: {}", addr)
+            );
             addr
         } else {
             debug!(
@@ -189,8 +192,10 @@ async fn main() {
         let cloned_url = matrix_url.clone();
 
         if let Some(acceptor) = tls_acceptor.clone() {
+            debug!(ctx.logger.as_ref(), "Using TLS acceptor");
+
             // Do the TLS handshake and then set up the bridge
-            let spawn_fut = future::lazy(move |_cx: &mut Context| async move {
+            let spawn_fut = async move {
                 debug!(ctx.logger.as_ref(), "Accepted connection");
 
                 let tls_socket = acceptor
@@ -222,7 +227,7 @@ async fn main() {
                 }
 
                 task_info!(ctx, "Finished");
-            });
+            };
 
             // We spawn the future off, otherwise we'd block the stream of incoming connections.
             // This is what causes the future to be in its own chain.
@@ -231,14 +236,19 @@ async fn main() {
             // possibly be `spawn` in the future after changing trait bounds.
             tokio::spawn(spawn_fut);
         } else {
+            debug!(ctx.logger.as_ref(), "Using non-tls connection");
+
             // Same as above except with less TLS.
-            let spawn_fut = future::lazy(move |_cx: &mut Context| async move {
+            let spawn_fut = async move {
                 debug!(ctx.logger.as_ref(), "Accepted connection");
 
                 let mut bridge =
                     bridge::Bridge::create(cloned_url, tcp_stream, irc_server_name, ctx.clone())
                         .await
                         .unwrap();
+
+                debug!(ctx.logger.as_ref(), "Successfully made bridge");
+
                 loop {
                     if let Err(e) = bridge.poll_irc().await {
                         task_warn!(ctx, "Encounted error while polling IRC connection"; "error" => format!{"{}", e});
@@ -249,7 +259,7 @@ async fn main() {
                         break;
                     }
                 }
-            });
+            };
 
             tokio::spawn(spawn_fut);
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,6 +250,8 @@ async fn main() {
                 debug!(ctx.logger.as_ref(), "Successfully made bridge");
 
                 loop {
+                    debug!(ctx.logger.as_ref(), "Polling bridge and matrix for changes");
+
                     if let Err(e) = bridge.poll_irc().await {
                         task_warn!(ctx, "Encounted error while polling IRC connection"; "error" => format!{"{}", e});
                         break;

--- a/src/matrix/sync.rs
+++ b/src/matrix/sync.rs
@@ -120,6 +120,7 @@ impl MatrixSyncClient {
 
                     task_trace!(self.ctx, "Got sync response"; "next_token" => sync_response.next_batch.clone());
                     self.next_token = Some(sync_response.next_batch.clone());
+                    *current_sync = RequestStatus::NoRequest;
                     return Poll::Ready(Ok(sync_response));
                 }
             };

--- a/src/matrix/sync.rs
+++ b/src/matrix/sync.rs
@@ -85,7 +85,7 @@ impl MatrixSyncClient {
                     };
 
                     // check response code to make sure the response was 200 Ok
-                    if response.status() == hyper::StatusCode::OK {
+                    if response.status() != hyper::StatusCode::OK {
                         return Poll::Ready(Err(io::Error::new(
                             io::ErrorKind::Other,
                             format!("Sync returned {}", response.status().as_u16()),

--- a/src/matrix/sync.rs
+++ b/src/matrix/sync.rs
@@ -84,7 +84,7 @@ impl MatrixSyncClient {
                         Poll::Pending => return Poll::Pending,
                     };
 
-                    // check response code to make sure the response was 200 Ok
+                    // error if the response code was not 200 OK
                     if response.status() != hyper::StatusCode::OK {
                         return Poll::Ready(Err(io::Error::new(
                             io::ErrorKind::Other,

--- a/src/stream_fold.rs
+++ b/src/stream_fold.rs
@@ -78,20 +78,15 @@ where
         let mut state = self.state.lock().unwrap();
 
         loop {
-            println! {"StreamFold iteration: {:?}", state} 
-
             match stream.as_mut().poll_next(cx) {
                 Poll::Ready(Some(item)) => {
                     if state.state_update(item) {
-                        println!("state was ready, returning");
                         return Poll::Ready(Some(()));
                     } else {
-                        println!("state was pending, continuing");
                         continue;
                     }
                 }
                 Poll::Ready(None) => {
-                    println! {"StreamFold got a none response"}
                     return Poll::Ready(None);
                 }
                 Poll::Pending => {
@@ -117,7 +112,7 @@ mod tests {
         B,
         C,
         D,
-        End
+        End,
     }
 
     #[derive(Default, Debug)]
@@ -139,13 +134,13 @@ mod tests {
                 Parts::B => self.b = Some(()),
                 Parts::C => self.c = Some(()),
                 Parts::D => self.d = Some(()),
-                Parts::End => return true
+                Parts::End => return true,
             }
             self.all_some()
         }
     }
 
-    // Sends all four of the required parts to the PartsCollected struct. Does not include a 
+    // Sends all four of the required parts to the PartsCollected struct. Does not include a
     // Parts::End since we expect the state to complete without it
     #[tokio::test]
     async fn good_fold() {
@@ -159,7 +154,6 @@ mod tests {
         let (_, state) = stream_fold.into_parts();
 
         assert_eq!(state.all_some(), true)
-        //
     }
 
     // Only send 3/4 parts to the PartsCollected state, and then send the EOF. The returned state

--- a/src/stream_fold.rs
+++ b/src/stream_fold.rs
@@ -66,7 +66,7 @@ where
 
 impl<W, T, V, S> Future for &StreamFold<S, W, T, V>
 where
-    W: StateUpdate<Result<T, V>> + std::fmt::Debug,
+    W: StateUpdate<Result<T, V>>,
     S: Stream<Item = Result<T, V>>,
 {
     type Output = Option<()>;


### PR DESCRIPTION
This PR adds a few things to the async await update:

* A new test to ensure `StreamFold` is implemented correctly. This was done as part of the debugging for the buffer issues below

* Add TLS support to http requests which previously flew under the radar

* A bunch of additional `trace!` level logging in addition to some extra `debug!` logging. Some of these may be unnecessary, feel free to give feedback on those.  

* Fix resizing the `read_buffer` when polling the underlying TCP connection used in the IRC server. Previously the buffer was not correctly returning to its original size if the TCP connection returned `Poll::Pending` on the first poll.

* Two minor bug fixes for the matrix module's http usage. Previously `RequestStatus` was not properly set to `NoRequest` when the underlying request future was completed which led to a panic. Additionally, `200 OK` responses were thrown out due to using `==` instead of `!=` when checking the status (whoops).

* use `async move {}` blocks instead of `futures::future::lazy(|_| {})` wherever possible
 